### PR TITLE
changed the post handler so that the request body MUST include certain tings.

### DIFF
--- a/src/route/POSThandler.ts
+++ b/src/route/POSThandler.ts
@@ -48,7 +48,7 @@ export function POSThandler(app: Express) {
 				errors.question = 'Please enter a question';
 			}
 		//I didn't know how to make it an array, becuase the req.body is a string
-		if (options.length !== 4) {
+		if (!Array.isArray(options) || options.length !== 4) {
 			errors.options = 'Please enter 4 options';
 		}
 


### PR DESCRIPTION
<img width="1036" alt="Screenshot 2024-06-05 at 12 47 45" src="https://github.com/fac29/P1DAAF-Backend/assets/112947016/f295c7bb-830d-45d1-82ad-315d4a2a86c2">

Hello fellow computer wizard. 

Here what I have tried to do is to stop people being able to SUBMIT a request body without
- question
- options
- answer
- 4 options
- a category
- a difficulty

I didn't do this for ` id` because in `add question` the form automatically adds it? @AlexVOiceover 


I didn't do the sanitize challenge so if someone has better insight please share. 


---
how to test

1. go onto POSTMAN/ BRUNO
2. make a POST request to http://localhost:3000/create-question
        here is an example bad request
        ``` {
          "id": "700",
          "category": "History",
          "difficulty": "easy",
          "question": "When was Princess Diana Born?",
          "timestamp": "10/10/10"
        }
        ```


